### PR TITLE
remove max content on logo

### DIFF
--- a/src/content/styles/Footer.scss
+++ b/src/content/styles/Footer.scss
@@ -17,7 +17,6 @@ Pulled from: https://bbbootstrap.com/snippets/social-media-icons-footer-54412302
 
 #sg-logo {
     width: 120px;
-    height: max-content;
     align-self: flex-end;
 }
 


### PR DESCRIPTION
Max content was stretching the logo on safari and causing it to look distorted.

<img width="565" alt="Screenshot 2023-07-04 at 1 24 03 PM" src="https://github.com/Solar-Gators/Advertisement-Website/assets/7267438/0b03b85a-00eb-4b58-8e6a-85a74f315878">
